### PR TITLE
Make define-command work when not at top level

### DIFF
--- a/parse.lisp
+++ b/parse.lisp
@@ -468,7 +468,7 @@ FOO
       (flet ((symcat (&rest syms)
                (intern (mapconcat (lambda (el) (string-upcase (string el)))
                                   syms "-"))))
-        `(progn
+        `(locally (declare (special ,command-line-run-p))
            (defvar ,command-line-run-p nil
              ,(format nil "True if running ~a from the command line."
                       (symbol-name name)))


### PR DESCRIPTION
A DEFVAR form was not being evaluated soon enough
to propagate the special declaration of its var
to subsequent uses in the expansion.  Change PROGN
to LOCALLY (DECLARE (SPECIAL ...)) ... to get
that information to the uses.